### PR TITLE
Add default m9k weapon values

### DIFF
--- a/lua/cfc_entity_stubber/m9k/assault_rifles/m9k_acr.lua
+++ b/lua/cfc_entity_stubber/m9k/assault_rifles/m9k_acr.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_acr" )
+    weapon.Primary.RPM = 825
+    weapon.Primary.ClipSize = 30
+    weapon.Primary.DefaultClip = 60
+    weapon.Primary.KickUp = 0.3
+    weapon.Primary.KickDown = 0.3
+    weapon.Primary.KickHorizontal = 0.3
+    weapon.Primary.Automatic = true
+    weapon.Primary.Ammo = "ar2"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 30
+    weapon.Primary.Spread = .025
+    weapon.Primary.IronAccuracy = .015
+end )

--- a/lua/cfc_entity_stubber/m9k/assault_rifles/m9k_ak47.lua
+++ b/lua/cfc_entity_stubber/m9k/assault_rifles/m9k_ak47.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_ak47" )
+    weapon.Primary.RPM = 600
+    weapon.Primary.ClipSize = 30
+    weapon.Primary.DefaultClip = 60
+    weapon.Primary.KickUp = 0.3
+    weapon.Primary.KickDown = 0.3
+    weapon.Primary.KickHorizontal = 0.3
+    weapon.Primary.Automatic = true
+    weapon.Primary.Ammo = "ar2"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 30
+    weapon.Primary.Spread = .023
+    weapon.Primary.IronAccuracy = .013
+end )

--- a/lua/cfc_entity_stubber/m9k/assault_rifles/m9k_ak74.lua
+++ b/lua/cfc_entity_stubber/m9k/assault_rifles/m9k_ak74.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_ak74" )
+    weapon.Primary.RPM = 600
+    weapon.Primary.ClipSize = 30
+    weapon.Primary.DefaultClip = 60
+    weapon.Primary.KickUp = 0.4
+    weapon.Primary.KickDown = 0.4
+    weapon.Primary.KickHorizontal = 0.4
+    weapon.Primary.Automatic = true
+    weapon.Primary.Ammo = "ar2"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 31
+    weapon.Primary.Spread = .02
+    weapon.Primary.IronAccuracy = .01
+end )

--- a/lua/cfc_entity_stubber/m9k/assault_rifles/m9k_amd65.lua
+++ b/lua/cfc_entity_stubber/m9k/assault_rifles/m9k_amd65.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_amd65" )
+    weapon.Primary.RPM = 750
+    weapon.Primary.ClipSize = 20
+    weapon.Primary.DefaultClip = 60
+    weapon.Primary.KickUp = .7
+    weapon.Primary.KickDown = 0.2
+    weapon.Primary.KickHorizontal = 0.4
+    weapon.Primary.Automatic = true
+    weapon.Primary.Ammo = "ar2"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 31
+    weapon.Primary.Spread = .021
+    weapon.Primary.IronAccuracy = .011
+end )

--- a/lua/cfc_entity_stubber/m9k/assault_rifles/m9k_an94.lua
+++ b/lua/cfc_entity_stubber/m9k/assault_rifles/m9k_an94.lua
@@ -1,0 +1,19 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_an94" )
+    weapon.Primary.RPM = 600
+    weapon.Primary.ClipSize = 30
+    weapon.Primary.DefaultClip = 60
+    weapon.Primary.KickUp = 0.3
+    weapon.Primary.KickDown = 0.1
+    weapon.Primary.KickHorizontal = 0.3
+    weapon.Primary.Automatic = true
+    weapon.Primary.Ammo = "ar2"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 31
+    weapon.Primary.Spread = .015
+    weapon.Primary.IronAccuracy = .005
+    weapon.Primary.Burst = false
+    weapon.Primary.PrevShots = weapon.Primary.NumShots
+end )

--- a/lua/cfc_entity_stubber/m9k/assault_rifles/m9k_auga3.lua
+++ b/lua/cfc_entity_stubber/m9k/assault_rifles/m9k_auga3.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_auga3" )
+    weapon.Primary.RPM = 700
+    weapon.Primary.ClipSize = 30
+    weapon.Primary.DefaultClip = 60
+    weapon.Primary.KickUp = .4
+    weapon.Primary.KickDown = .4
+    weapon.Primary.KickHorizontal = .5
+    weapon.Primary.Automatic = true
+    weapon.Primary.Ammo = "ar2"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 22
+    weapon.Primary.Spread = .025
+    weapon.Primary.IronAccuracy = .02
+end )

--- a/lua/cfc_entity_stubber/m9k/assault_rifles/m9k_f2000.lua
+++ b/lua/cfc_entity_stubber/m9k/assault_rifles/m9k_f2000.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_f2000" )
+    weapon.Primary.RPM = 850
+    weapon.Primary.ClipSize = 30
+    weapon.Primary.DefaultClip = 60
+    weapon.Primary.KickUp = .4
+    weapon.Primary.KickDown = .4
+    weapon.Primary.KickHorizontal = .4
+    weapon.Primary.Automatic = true
+    weapon.Primary.Ammo = "smg1"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 23
+    weapon.Primary.Spread = .025
+    weapon.Primary.IronAccuracy = .015
+end )

--- a/lua/cfc_entity_stubber/m9k/assault_rifles/m9k_fal.lua
+++ b/lua/cfc_entity_stubber/m9k/assault_rifles/m9k_fal.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_fal" )
+    weapon.Primary.RPM = 750
+    weapon.Primary.ClipSize = 20
+    weapon.Primary.DefaultClip = 60
+    weapon.Primary.KickUp = 0.5
+    weapon.Primary.KickDown = 0.3
+    weapon.Primary.KickHorizontal = 0.5
+    weapon.Primary.Automatic = false
+    weapon.Primary.Ammo = "ar2"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 30
+    weapon.Primary.Spread = .02
+    weapon.Primary.IronAccuracy = .01
+end )

--- a/lua/cfc_entity_stubber/m9k/assault_rifles/m9k_famas.lua
+++ b/lua/cfc_entity_stubber/m9k/assault_rifles/m9k_famas.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_famas" )
+    weapon.Primary.RPM = 950
+    weapon.Primary.ClipSize = 30
+    weapon.Primary.DefaultClip = 60
+    weapon.Primary.KickUp = 0.4
+    weapon.Primary.KickDown = 0.4
+    weapon.Primary.KickHorizontal = 0.4
+    weapon.Primary.Automatic = true
+    weapon.Primary.Ammo = "ar2"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 29
+    weapon.Primary.Spread = .025
+    weapon.Primary.IronAccuracy = .015
+end )

--- a/lua/cfc_entity_stubber/m9k/assault_rifles/m9k_g36.lua
+++ b/lua/cfc_entity_stubber/m9k/assault_rifles/m9k_g36.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_g36" )
+    weapon.Primary.RPM = 750
+    weapon.Primary.ClipSize = 30
+    weapon.Primary.DefaultClip = 60
+    weapon.Primary.KickUp = 0.3
+    weapon.Primary.KickDown = 0.3
+    weapon.Primary.KickHorizontal = 0.3
+    weapon.Primary.Automatic = true
+    weapon.Primary.Ammo = "ar2"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 28
+    weapon.Primary.Spread = .02
+    weapon.Primary.IronAccuracy = .01
+end )

--- a/lua/cfc_entity_stubber/m9k/assault_rifles/m9k_g3a3.lua
+++ b/lua/cfc_entity_stubber/m9k/assault_rifles/m9k_g3a3.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_g3a3" )
+    weapon.Primary.RPM = 550
+    weapon.Primary.ClipSize = 20
+    weapon.Primary.DefaultClip = 60
+    weapon.Primary.KickUp = 0.4
+    weapon.Primary.KickDown = 0.3
+    weapon.Primary.KickHorizontal = 0.5
+    weapon.Primary.Automatic = true
+    weapon.Primary.Ammo = "ar2"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 33
+    weapon.Primary.Spread = .026
+    weapon.Primary.IronAccuracy = .016
+end )

--- a/lua/cfc_entity_stubber/m9k/assault_rifles/m9k_l85.lua
+++ b/lua/cfc_entity_stubber/m9k/assault_rifles/m9k_l85.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_l85" )
+    weapon.Primary.RPM = 675
+    weapon.Primary.ClipSize = 30
+    weapon.Primary.DefaultClip = 60
+    weapon.Primary.KickUp = .4
+    weapon.Primary.KickDown = .4
+    weapon.Primary.KickHorizontal = .5
+    weapon.Primary.Automatic = true
+    weapon.Primary.Ammo = "ar2"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 29
+    weapon.Primary.Spread = .023
+    weapon.Primary.IronAccuracy = .015
+end )

--- a/lua/cfc_entity_stubber/m9k/assault_rifles/m9k_m14sp.lua
+++ b/lua/cfc_entity_stubber/m9k/assault_rifles/m9k_m14sp.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_m14sp" )
+    weapon.Primary.RPM = 750
+    weapon.Primary.ClipSize = 20
+    weapon.Primary.DefaultClip = 60
+    weapon.Primary.KickUp = 0.6
+    weapon.Primary.KickDown = 0.6
+    weapon.Primary.KickHorizontal = 0.6
+    weapon.Primary.Automatic = false
+    weapon.Primary.Ammo = "ar2"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 32
+    weapon.Primary.Spread = .01
+    weapon.Primary.IronAccuracy = .001
+end )

--- a/lua/cfc_entity_stubber/m9k/assault_rifles/m9k_m16a4_acog.lua
+++ b/lua/cfc_entity_stubber/m9k/assault_rifles/m9k_m16a4_acog.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_m16a4_acog" )
+    weapon.Primary.RPM = 850
+    weapon.Primary.ClipSize = 30
+    weapon.Primary.DefaultClip = 60
+    weapon.Primary.KickUp = .4
+    weapon.Primary.KickDown = .4
+    weapon.Primary.KickHorizontal = .6
+    weapon.Primary.Automatic = false
+    weapon.Primary.Ammo = "ar2"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 30
+    weapon.Primary.Spread = .015
+    weapon.Primary.IronAccuracy = .01
+end )

--- a/lua/cfc_entity_stubber/m9k/assault_rifles/m9k_m416.lua
+++ b/lua/cfc_entity_stubber/m9k/assault_rifles/m9k_m416.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_m416" )
+    weapon.Primary.RPM = 800
+    weapon.Primary.ClipSize = 30
+    weapon.Primary.DefaultClip = 60
+    weapon.Primary.KickUp = 0.4
+    weapon.Primary.KickDown = 0.4
+    weapon.Primary.KickHorizontal = 0.6
+    weapon.Primary.Automatic = true
+    weapon.Primary.Ammo = "ar2"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 30
+    weapon.Primary.Spread = .025
+    weapon.Primary.IronAccuracy = .015
+end )

--- a/lua/cfc_entity_stubber/m9k/assault_rifles/m9k_m4a1.lua
+++ b/lua/cfc_entity_stubber/m9k/assault_rifles/m9k_m4a1.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_m4a1" )
+    weapon.Primary.RPM = 800
+    weapon.Primary.ClipSize = 30
+    weapon.Primary.DefaultClip = 60
+    weapon.Primary.KickUp = 0.4
+    weapon.Primary.KickDown = 0.4
+    weapon.Primary.KickHorizontal = 0.5
+    weapon.Primary.Automatic = true
+    weapon.Primary.Ammo = "ar2"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 30
+    weapon.Primary.Spread = .02
+    weapon.Primary.IronAccuracy = .01
+end )

--- a/lua/cfc_entity_stubber/m9k/assault_rifles/m9k_scar.lua
+++ b/lua/cfc_entity_stubber/m9k/assault_rifles/m9k_scar.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_scar" )
+    weapon.Primary.RPM = 625
+    weapon.Primary.ClipSize = 30
+    weapon.Primary.DefaultClip = 60
+    weapon.Primary.KickUp = 0.4
+    weapon.Primary.KickDown = 0.3
+    weapon.Primary.KickHorizontal = 0.3
+    weapon.Primary.Automatic = true
+    weapon.Primary.Ammo = "ar2"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 30
+    weapon.Primary.Spread = .02
+    weapon.Primary.IronAccuracy = .01
+end )

--- a/lua/cfc_entity_stubber/m9k/assault_rifles/m9k_tar21.lua
+++ b/lua/cfc_entity_stubber/m9k/assault_rifles/m9k_tar21.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_tar21" )
+    weapon.Primary.RPM = 900
+    weapon.Primary.ClipSize = 30
+    weapon.Primary.DefaultClip = 60
+    weapon.Primary.KickUp = 0.3
+    weapon.Primary.KickDown = 0.3
+    weapon.Primary.KickHorizontal = 0.3
+    weapon.Primary.Automatic = true
+    weapon.Primary.Ammo = "ar2"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 30
+    weapon.Primary.Spread = .027
+    weapon.Primary.IronAccuracy = .016
+end )

--- a/lua/cfc_entity_stubber/m9k/assault_rifles/m9k_val.lua
+++ b/lua/cfc_entity_stubber/m9k/assault_rifles/m9k_val.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_val" )
+    weapon.Primary.RPM = 900
+    weapon.Primary.ClipSize = 20
+    weapon.Primary.DefaultClip = 60
+    weapon.Primary.KickUp = 0.3
+    weapon.Primary.KickDown = 0.3
+    weapon.Primary.KickHorizontal = 0.5
+    weapon.Primary.Automatic = true
+    weapon.Primary.Ammo = "ar2"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 27
+    weapon.Primary.Spread = .019
+    weapon.Primary.IronAccuracy = .008
+end )

--- a/lua/cfc_entity_stubber/m9k/assault_rifles/m9k_vikhr.lua
+++ b/lua/cfc_entity_stubber/m9k/assault_rifles/m9k_vikhr.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_vikhr" )
+    weapon.Primary.RPM = 900
+    weapon.Primary.ClipSize = 30
+    weapon.Primary.DefaultClip = 60
+    weapon.Primary.KickUp = 0.3
+    weapon.Primary.KickDown = 0.3
+    weapon.Primary.KickHorizontal = 0.5
+    weapon.Primary.Automatic = true
+    weapon.Primary.Ammo = "smg1"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 29
+    weapon.Primary.Spread = .02
+    weapon.Primary.IronAccuracy = .014
+end )

--- a/lua/cfc_entity_stubber/m9k/assault_rifles/m9k_winchester73.lua
+++ b/lua/cfc_entity_stubber/m9k/assault_rifles/m9k_winchester73.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_winchester73" )
+    weapon.Primary.RPM = 66
+    weapon.Primary.ClipSize = 8
+    weapon.Primary.DefaultClip = 30
+    weapon.Primary.KickUp = .2
+    weapon.Primary.KickDown = 0
+    weapon.Primary.KickHorizontal = 0.1
+    weapon.Primary.Automatic = false
+    weapon.Primary.Ammo = "AirboatGun"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 85
+    weapon.Primary.Spread = .01
+    weapon.Primary.IronAccuracy = .001
+end )

--- a/lua/cfc_entity_stubber/m9k/heavy_weapons/m9k_1887winchester.lua
+++ b/lua/cfc_entity_stubber/m9k/heavy_weapons/m9k_1887winchester.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_1887winchester" )
+    weapon.Primary.RPM = 70
+    weapon.Primary.ClipSize = 4
+    weapon.Primary.DefaultClip = 12
+    weapon.Primary.KickUp = 1
+    weapon.Primary.KickDown = 0.8
+    weapon.Primary.KickHorizontal = 0.6
+    weapon.Primary.Automatic = false
+    weapon.Primary.Ammo = "slam"
+    weapon.Primary.NumShots = 10
+    weapon.Primary.Damage = 10
+    weapon.Primary.Spread = .042
+    weapon.Primary.IronAccuracy = .042
+end )

--- a/lua/cfc_entity_stubber/m9k/heavy_weapons/m9k_1897winchester.lua
+++ b/lua/cfc_entity_stubber/m9k/heavy_weapons/m9k_1897winchester.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_1897winchester" )
+    weapon.Primary.RPM = 70
+    weapon.Primary.ClipSize = 4
+    weapon.Primary.DefaultClip = 12
+    weapon.Primary.KickUp = 0.9
+    weapon.Primary.KickDown = 0.6
+    weapon.Primary.KickHorizontal = 0.4
+    weapon.Primary.Automatic = false
+    weapon.Primary.Ammo = "slam"
+    weapon.Primary.NumShots = 11//howmanybulletstoshoot,usewithshotguns
+    weapon.Primary.Damage = 10//basedamage,scaledbygame
+    weapon.Primary.Spread = .04//definefrom
+    weapon.Primary.IronAccuracy = .04//hastobethesameasprimary.spread
+end )

--- a/lua/cfc_entity_stubber/m9k/heavy_weapons/m9k_ares_shrike.lua
+++ b/lua/cfc_entity_stubber/m9k/heavy_weapons/m9k_ares_shrike.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_ares_shrike" )
+    weapon.Primary.RPM = 650
+    weapon.Primary.ClipSize = 200
+    weapon.Primary.DefaultClip = 400
+    weapon.Primary.KickUp = 0.6
+    weapon.Primary.KickDown = 0.4
+    weapon.Primary.KickHorizontal = 0.5
+    weapon.Primary.Automatic = true
+    weapon.Primary.Ammo = "ar2"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 30
+    weapon.Primary.Spread = .03
+    weapon.Primary.IronAccuracy = .02
+end )

--- a/lua/cfc_entity_stubber/m9k/heavy_weapons/m9k_aw50.lua
+++ b/lua/cfc_entity_stubber/m9k/heavy_weapons/m9k_aw50.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_aw50" )
+    weapon.Primary.RPM = 50
+    weapon.Primary.ClipSize = 10
+    weapon.Primary.DefaultClip = 60
+    weapon.Primary.KickUp = 1
+    weapon.Primary.KickDown = 1
+    weapon.Primary.KickHorizontal = 1
+    weapon.Primary.Automatic = false
+    weapon.Primary.Ammo = "SniperPenetratedRound"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 95
+    weapon.Primary.Spread = .01
+    weapon.Primary.IronAccuracy = .0001
+end )

--- a/lua/cfc_entity_stubber/m9k/heavy_weapons/m9k_barret_m82.lua
+++ b/lua/cfc_entity_stubber/m9k/heavy_weapons/m9k_barret_m82.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_barret_m82" )
+    weapon.Primary.RPM = 200
+    weapon.Primary.ClipSize = 10
+    weapon.Primary.DefaultClip = 60
+    weapon.Primary.KickUp = 1
+    weapon.Primary.KickDown = 1
+    weapon.Primary.KickHorizontal = 1
+    weapon.Primary.Automatic = false
+    weapon.Primary.Ammo = "SniperPenetratedRound"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 110
+    weapon.Primary.Spread = .01
+    weapon.Primary.IronAccuracy = .00001
+end )

--- a/lua/cfc_entity_stubber/m9k/heavy_weapons/m9k_browningauto5.lua
+++ b/lua/cfc_entity_stubber/m9k/heavy_weapons/m9k_browningauto5.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_browningauto5" )
+    weapon.Primary.RPM = 250
+    weapon.Primary.ClipSize = 6
+    weapon.Primary.DefaultClip = 30
+    weapon.Primary.KickUp = 1
+    weapon.Primary.KickDown = 0.8
+    weapon.Primary.KickHorizontal = 0.6
+    weapon.Primary.Automatic = false
+    weapon.Primary.Ammo = "buckshot"
+    weapon.Primary.NumShots = 9//howmanybulletstoshoot,usewithshotguns
+    weapon.Primary.Damage = 10//basedamage,scaledbygame
+    weapon.Primary.Spread = .03//definefrom
+    weapon.Primary.IronAccuracy = .03//hastobethesameasprimary.spread
+end )

--- a/lua/cfc_entity_stubber/m9k/heavy_weapons/m9k_contender.lua
+++ b/lua/cfc_entity_stubber/m9k/heavy_weapons/m9k_contender.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_contender" )
+    weapon.Primary.RPM = 35
+    weapon.Primary.ClipSize = 1
+    weapon.Primary.DefaultClip = 60
+    weapon.Primary.KickUp = 1
+    weapon.Primary.KickDown = 1
+    weapon.Primary.KickHorizontal = 1
+    weapon.Primary.Automatic = false
+    weapon.Primary.Ammo = "ar2"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 85
+    weapon.Primary.Spread = .01
+    weapon.Primary.IronAccuracy = .00015
+end )

--- a/lua/cfc_entity_stubber/m9k/heavy_weapons/m9k_dbarrel.lua
+++ b/lua/cfc_entity_stubber/m9k/heavy_weapons/m9k_dbarrel.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_dbarrel" )
+    weapon.Primary.RPM = 180
+    weapon.Primary.ClipSize = 2
+    weapon.Primary.DefaultClip = 30
+    weapon.Primary.KickUp = 10
+    weapon.Primary.KickDown = 5
+    weapon.Primary.KickHorizontal = 5
+    weapon.Primary.Automatic = false
+    weapon.Primary.Ammo = "buckshot"
+    weapon.Primary.NumShots = 18
+    weapon.Primary.Damage = 10
+    weapon.Primary.Spread = .03
+    weapon.Primary.IronAccuracy = .03
+end )

--- a/lua/cfc_entity_stubber/m9k/heavy_weapons/m9k_dragunov.lua
+++ b/lua/cfc_entity_stubber/m9k/heavy_weapons/m9k_dragunov.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_dragunov" )
+    weapon.Primary.RPM = 400
+    weapon.Primary.ClipSize = 10
+    weapon.Primary.DefaultClip = 60
+    weapon.Primary.KickUp = 1
+    weapon.Primary.KickDown = .6
+    weapon.Primary.KickHorizontal = .5
+    weapon.Primary.Automatic = false
+    weapon.Primary.Ammo = "SniperPenetratedRound"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 90
+    weapon.Primary.Spread = .01
+    weapon.Primary.IronAccuracy = .00012
+end )

--- a/lua/cfc_entity_stubber/m9k/heavy_weapons/m9k_fg42.lua
+++ b/lua/cfc_entity_stubber/m9k/heavy_weapons/m9k_fg42.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_fg42" )
+    weapon.Primary.RPM = 900
+    weapon.Primary.ClipSize = 20
+    weapon.Primary.DefaultClip = 60
+    weapon.Primary.KickUp = 0.3
+    weapon.Primary.KickDown = 0.3
+    weapon.Primary.KickHorizontal = 0.3
+    weapon.Primary.Automatic = true
+    weapon.Primary.Ammo = "ar2"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 38
+    weapon.Primary.Spread = .02
+    weapon.Primary.IronAccuracy = .01
+end )

--- a/lua/cfc_entity_stubber/m9k/heavy_weapons/m9k_intervention.lua
+++ b/lua/cfc_entity_stubber/m9k/heavy_weapons/m9k_intervention.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_intervention" )
+    weapon.Primary.RPM = 35
+    weapon.Primary.ClipSize = 5
+    weapon.Primary.DefaultClip = 60
+    weapon.Primary.KickUp = 1
+    weapon.Primary.KickDown = .6
+    weapon.Primary.KickHorizontal = .4
+    weapon.Primary.Automatic = false
+    weapon.Primary.Ammo = "SniperPenetratedRound"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 95
+    weapon.Primary.Spread = .01
+    weapon.Primary.IronAccuracy = .0001
+end )

--- a/lua/cfc_entity_stubber/m9k/heavy_weapons/m9k_ithacam37.lua
+++ b/lua/cfc_entity_stubber/m9k/heavy_weapons/m9k_ithacam37.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_ithacam37" )
+    weapon.Primary.RPM = 60
+    weapon.Primary.ClipSize = 6
+    weapon.Primary.DefaultClip = 30
+    weapon.Primary.KickUp = .9
+    weapon.Primary.KickDown = 0.6
+    weapon.Primary.KickHorizontal = 0.6
+    weapon.Primary.Automatic = false
+    weapon.Primary.Ammo = "buckshot"
+    weapon.Primary.NumShots = 8
+    weapon.Primary.Damage = 12
+    weapon.Primary.Spread = .023
+    weapon.Primary.IronAccuracy = .023
+end )

--- a/lua/cfc_entity_stubber/m9k/heavy_weapons/m9k_jackhammer.lua
+++ b/lua/cfc_entity_stubber/m9k/heavy_weapons/m9k_jackhammer.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_jackhammer" )
+    weapon.Primary.RPM = 240
+    weapon.Primary.ClipSize = 10
+    weapon.Primary.DefaultClip = 30
+    weapon.Primary.KickUp = 1
+    weapon.Primary.KickDown = 0.5
+    weapon.Primary.KickHorizontal = 0.4
+    weapon.Primary.Automatic = true
+    weapon.Primary.Ammo = "buckshot"
+    weapon.Primary.NumShots = 6
+    weapon.Primary.Damage = 10
+    weapon.Primary.Spread = .045
+    weapon.Primary.IronAccuracy = .045
+end )

--- a/lua/cfc_entity_stubber/m9k/heavy_weapons/m9k_m1918bar.lua
+++ b/lua/cfc_entity_stubber/m9k/heavy_weapons/m9k_m1918bar.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_m1918bar" )
+    weapon.Primary.RPM = 450
+    weapon.Primary.ClipSize = 20
+    weapon.Primary.DefaultClip = 60
+    weapon.Primary.KickUp = 0.6
+    weapon.Primary.KickDown = 0.4
+    weapon.Primary.KickHorizontal = 0.5
+    weapon.Primary.Automatic = true
+    weapon.Primary.Ammo = "ar2"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 40
+    weapon.Primary.Spread = .025
+    weapon.Primary.IronAccuracy = .015
+end )

--- a/lua/cfc_entity_stubber/m9k/heavy_weapons/m9k_m24.lua
+++ b/lua/cfc_entity_stubber/m9k/heavy_weapons/m9k_m24.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_m24" )
+    weapon.Primary.RPM = 40
+    weapon.Primary.ClipSize = 5
+    weapon.Primary.DefaultClip = 60
+    weapon.Primary.KickUp = .6
+    weapon.Primary.KickDown = .6
+    weapon.Primary.KickHorizontal = .6
+    weapon.Primary.Automatic = false
+    weapon.Primary.Ammo = "SniperPenetratedRound"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 97
+    weapon.Primary.Spread = .01
+    weapon.Primary.IronAccuracy = .000115
+end )

--- a/lua/cfc_entity_stubber/m9k/heavy_weapons/m9k_m249lmg.lua
+++ b/lua/cfc_entity_stubber/m9k/heavy_weapons/m9k_m249lmg.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_m249lmg" )
+    weapon.Primary.RPM = 855
+    weapon.Primary.ClipSize = 150
+    weapon.Primary.DefaultClip = 300
+    weapon.Primary.KickUp = 0.6
+    weapon.Primary.KickDown = 0.4
+    weapon.Primary.KickHorizontal = 0.5
+    weapon.Primary.Automatic = true
+    weapon.Primary.Ammo = "ar2"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 27
+    weapon.Primary.Spread = .035
+    weapon.Primary.IronAccuracy = .024
+end )

--- a/lua/cfc_entity_stubber/m9k/heavy_weapons/m9k_m3.lua
+++ b/lua/cfc_entity_stubber/m9k/heavy_weapons/m9k_m3.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_m3" )
+    weapon.Primary.RPM = 70
+    weapon.Primary.ClipSize = 8
+    weapon.Primary.DefaultClip = 30
+    weapon.Primary.KickUp = 0.8
+    weapon.Primary.KickDown = 0.5
+    weapon.Primary.KickHorizontal = 0.3
+    weapon.Primary.Automatic = false
+    weapon.Primary.Ammo = "buckshot"
+    weapon.Primary.NumShots = 9
+    weapon.Primary.Damage = 10
+    weapon.Primary.Spread = .0326
+    weapon.Primary.IronAccuracy = .0326
+end )

--- a/lua/cfc_entity_stubber/m9k/heavy_weapons/m9k_m60.lua
+++ b/lua/cfc_entity_stubber/m9k/heavy_weapons/m9k_m60.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_m60" )
+    weapon.Primary.RPM = 575
+    weapon.Primary.ClipSize = 200
+    weapon.Primary.DefaultClip = 400
+    weapon.Primary.KickUp = 0.6
+    weapon.Primary.KickDown = 0.4
+    weapon.Primary.KickHorizontal = 0.5
+    weapon.Primary.Automatic = true
+    weapon.Primary.Ammo = "ar2"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 33
+    weapon.Primary.Spread = .035
+    weapon.Primary.IronAccuracy = .025
+end )

--- a/lua/cfc_entity_stubber/m9k/heavy_weapons/m9k_m98b.lua
+++ b/lua/cfc_entity_stubber/m9k/heavy_weapons/m9k_m98b.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_m98b" )
+    weapon.Primary.RPM = 50
+    weapon.Primary.ClipSize = 10
+    weapon.Primary.DefaultClip = 60
+    weapon.Primary.KickUp = 1
+    weapon.Primary.KickDown = 1
+    weapon.Primary.KickHorizontal = 1
+    weapon.Primary.Automatic = false
+    weapon.Primary.Ammo = "SniperPenetratedRound"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 90
+    weapon.Primary.Spread = .001
+    weapon.Primary.IronAccuracy = .0001
+end )

--- a/lua/cfc_entity_stubber/m9k/heavy_weapons/m9k_minigun.lua
+++ b/lua/cfc_entity_stubber/m9k/heavy_weapons/m9k_minigun.lua
@@ -1,19 +1,19 @@
 AddCSLuaFile()
 
-CFC_M9k_Stubber.registerStub( function()
-    local SWEP = cfcEntityStubber.getWeapon( "m9k_minigun" )
-    
-    SWEP.Primary.RPM = 1500
-    SWEP.Primary.ClipSize = 300
-    SWEP.Primary.DefaultClip = 0
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_minigun" )
 
-    SWEP.Primary.KickUp = 1.5
-    SWEP.Primary.KickDown = 0.2
-    SWEP.Primary.KickHorizontal = 0.2
-    SWEP.Primary.Automatic = true
-    SWEP.Primary.Ammo = "ar2"
-    SWEP.Primary.NumShots = 2
-    SWEP.Primary.Damage = 6
-    SWEP.Primary.Spread = .06
-    SWEP.Primary.IronAccuracy = .08
+    weapon.Primary.RPM = 1500
+    weapon.Primary.ClipSize = 300
+    weapon.Primary.DefaultClip = 0
+
+    weapon.Primary.KickUp = 1.5
+    weapon.Primary.KickDown = 0.2
+    weapon.Primary.KickHorizontal = 0.2
+    weapon.Primary.Automatic = true
+    weapon.Primary.Ammo = "ar2"
+    weapon.Primary.NumShots = 2
+    weapon.Primary.Damage = 6
+    weapon.Primary.Spread = .06
+    weapon.Primary.IronAccuracy = .08
 end )

--- a/lua/cfc_entity_stubber/m9k/heavy_weapons/m9k_mossberg590.lua
+++ b/lua/cfc_entity_stubber/m9k/heavy_weapons/m9k_mossberg590.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_mossberg590" )
+    weapon.Primary.RPM = 75
+    weapon.Primary.ClipSize = 8
+    weapon.Primary.DefaultClip = 30
+    weapon.Primary.KickUp = 1
+    weapon.Primary.KickDown = 0.8
+    weapon.Primary.KickHorizontal = 0.8
+    weapon.Primary.Automatic = false
+    weapon.Primary.Ammo = "buckshot"
+    weapon.Primary.NumShots = 10
+    weapon.Primary.Damage = 9
+    weapon.Primary.Spread = .03
+    weapon.Primary.IronAccuracy = .03
+end )

--- a/lua/cfc_entity_stubber/m9k/heavy_weapons/m9k_pkm.lua
+++ b/lua/cfc_entity_stubber/m9k/heavy_weapons/m9k_pkm.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_pkm" )
+    weapon.Primary.RPM = 750
+    weapon.Primary.ClipSize = 100
+    weapon.Primary.DefaultClip = 200
+    weapon.Primary.KickUp = 0.6
+    weapon.Primary.KickDown = 0.3
+    weapon.Primary.KickHorizontal = 0.5
+    weapon.Primary.Automatic = true
+    weapon.Primary.Ammo = "ar2"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 33
+    weapon.Primary.Spread = .035
+    weapon.Primary.IronAccuracy = .02
+end )

--- a/lua/cfc_entity_stubber/m9k/heavy_weapons/m9k_psg1.lua
+++ b/lua/cfc_entity_stubber/m9k/heavy_weapons/m9k_psg1.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_psg1" )
+    weapon.Primary.RPM = 500
+    weapon.Primary.ClipSize = 10
+    weapon.Primary.DefaultClip = 60
+    weapon.Primary.KickUp = 1
+    weapon.Primary.KickDown = 1
+    weapon.Primary.KickHorizontal = 1
+    weapon.Primary.Automatic = false
+    weapon.Primary.Ammo = "SniperPenetratedRound"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 90
+    weapon.Primary.Spread = .01
+    weapon.Primary.IronAccuracy = .0001
+end )

--- a/lua/cfc_entity_stubber/m9k/heavy_weapons/m9k_remington7615p.lua
+++ b/lua/cfc_entity_stubber/m9k/heavy_weapons/m9k_remington7615p.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_remington7615p" )
+    weapon.Primary.RPM = 50
+    weapon.Primary.ClipSize = 10
+    weapon.Primary.DefaultClip = 60
+    weapon.Primary.KickUp = 1
+    weapon.Primary.KickDown = 1
+    weapon.Primary.KickHorizontal = 1
+    weapon.Primary.Automatic = false
+    weapon.Primary.Ammo = "ar2"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 35
+    weapon.Primary.Spread = .01
+    weapon.Primary.IronAccuracy = .001
+end )

--- a/lua/cfc_entity_stubber/m9k/heavy_weapons/m9k_remington870.lua
+++ b/lua/cfc_entity_stubber/m9k/heavy_weapons/m9k_remington870.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_remington870" )
+    weapon.Primary.RPM = 70
+    weapon.Primary.ClipSize = 8
+    weapon.Primary.DefaultClip = 30
+    weapon.Primary.KickUp = 1.25
+    weapon.Primary.KickDown = 0.8
+    weapon.Primary.KickHorizontal = 0.4
+    weapon.Primary.Automatic = false
+    weapon.Primary.Ammo = "buckshot"
+    weapon.Primary.NumShots = 9
+    weapon.Primary.Damage = 10
+    weapon.Primary.Spread = .035
+    weapon.Primary.IronAccuracy = .035
+end )

--- a/lua/cfc_entity_stubber/m9k/heavy_weapons/m9k_sl8.lua
+++ b/lua/cfc_entity_stubber/m9k/heavy_weapons/m9k_sl8.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_sl8" )
+    weapon.Primary.RPM = 300
+    weapon.Primary.ClipSize = 30
+    weapon.Primary.DefaultClip = 60
+    weapon.Primary.KickUp = .6
+    weapon.Primary.KickDown = .6
+    weapon.Primary.KickHorizontal = .6
+    weapon.Primary.Automatic = true
+    weapon.Primary.Ammo = "ar2"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 60
+    weapon.Primary.Spread = .015
+    weapon.Primary.IronAccuracy = .001
+end )

--- a/lua/cfc_entity_stubber/m9k/heavy_weapons/m9k_spas12.lua
+++ b/lua/cfc_entity_stubber/m9k/heavy_weapons/m9k_spas12.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_spas12" )
+    weapon.Primary.RPM = 350
+    weapon.Primary.ClipSize = 8
+    weapon.Primary.DefaultClip = 30
+    weapon.Primary.KickUp = 1.5
+    weapon.Primary.KickDown = 0.3
+    weapon.Primary.KickHorizontal = 0.7
+    weapon.Primary.Automatic = false
+    weapon.Primary.Ammo = "buckshot"
+    weapon.Primary.NumShots = 10
+    weapon.Primary.Damage = 10
+    weapon.Primary.Spread = .03
+    weapon.Primary.IronAccuracy = .03
+end )

--- a/lua/cfc_entity_stubber/m9k/heavy_weapons/m9k_striker12.lua
+++ b/lua/cfc_entity_stubber/m9k/heavy_weapons/m9k_striker12.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_striker12" )
+    weapon.Primary.RPM = 365
+    weapon.Primary.ClipSize = 12
+    weapon.Primary.DefaultClip = 36
+    weapon.Primary.KickUp = 4
+    weapon.Primary.KickDown = 0.5
+    weapon.Primary.KickHorizontal = .6
+    weapon.Primary.Automatic = true
+    weapon.Primary.Ammo = "buckshot"
+    weapon.Primary.NumShots = 6
+    weapon.Primary.Damage = 8
+    weapon.Primary.Spread = .04
+    weapon.Primary.IronAccuracy = .04
+end )

--- a/lua/cfc_entity_stubber/m9k/heavy_weapons/m9k_svt40.lua
+++ b/lua/cfc_entity_stubber/m9k/heavy_weapons/m9k_svt40.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_svt40" )
+    weapon.Primary.RPM = 350
+    weapon.Primary.ClipSize = 10
+    weapon.Primary.DefaultClip = 60
+    weapon.Primary.KickUp = 1
+    weapon.Primary.KickDown = 1
+    weapon.Primary.KickHorizontal = 1
+    weapon.Primary.Automatic = false
+    weapon.Primary.Ammo = "ar2"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 80
+    weapon.Primary.Spread = .01
+    weapon.Primary.IronAccuracy = .0001
+end )

--- a/lua/cfc_entity_stubber/m9k/heavy_weapons/m9k_svu.lua
+++ b/lua/cfc_entity_stubber/m9k/heavy_weapons/m9k_svu.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_svu" )
+    weapon.Primary.RPM = 400
+    weapon.Primary.ClipSize = 10
+    weapon.Primary.DefaultClip = 60
+    weapon.Primary.KickUp = 1
+    weapon.Primary.KickDown = 1
+    weapon.Primary.KickHorizontal = 1
+    weapon.Primary.Automatic = false
+    weapon.Primary.Ammo = "SniperPenetratedRound"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 93
+    weapon.Primary.Spread = .01
+    weapon.Primary.IronAccuracy = .0001
+end )

--- a/lua/cfc_entity_stubber/m9k/heavy_weapons/m9k_usas.lua
+++ b/lua/cfc_entity_stubber/m9k/heavy_weapons/m9k_usas.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_usas" )
+    weapon.Primary.RPM = 260
+    weapon.Primary.ClipSize = 20
+    weapon.Primary.DefaultClip = 60
+    weapon.Primary.KickUp = 1
+    weapon.Primary.KickDown = 0.4
+    weapon.Primary.KickHorizontal = 0.7
+    weapon.Primary.Automatic = true
+    weapon.Primary.Ammo = "buckshot"
+    weapon.Primary.NumShots = 10
+    weapon.Primary.Damage = 7
+    weapon.Primary.Spread = .048
+    weapon.Primary.IronAccuracy = .048
+end )

--- a/lua/cfc_entity_stubber/m9k/small_arms/m9k_bizonp19.lua
+++ b/lua/cfc_entity_stubber/m9k/small_arms/m9k_bizonp19.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_bizonp19" )
+    weapon.Primary.RPM = 675
+    weapon.Primary.ClipSize = 64
+    weapon.Primary.DefaultClip = 128
+    weapon.Primary.KickUp = 0.6
+    weapon.Primary.KickDown = 0.4
+    weapon.Primary.KickHorizontal = 0.5
+    weapon.Primary.Automatic = true
+    weapon.Primary.Ammo = "smg1"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 19
+    weapon.Primary.Spread = .02
+    weapon.Primary.IronAccuracy = .015
+end )

--- a/lua/cfc_entity_stubber/m9k/small_arms/m9k_colt1911.lua
+++ b/lua/cfc_entity_stubber/m9k/small_arms/m9k_colt1911.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_colt1911" )
+    weapon.Primary.RPM = 700
+    weapon.Primary.ClipSize = 7
+    weapon.Primary.DefaultClip = 45
+    weapon.Primary.KickUp = 0.4
+    weapon.Primary.KickDown = 0.3
+    weapon.Primary.KickHorizontal = 0.3
+    weapon.Primary.Automatic = false
+    weapon.Primary.Ammo = "pistol"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 17
+    weapon.Primary.Spread = .025
+    weapon.Primary.IronAccuracy = .015
+end )

--- a/lua/cfc_entity_stubber/m9k/small_arms/m9k_coltpython.lua
+++ b/lua/cfc_entity_stubber/m9k/small_arms/m9k_coltpython.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_coltpython" )
+    weapon.Primary.RPM = 115
+    weapon.Primary.ClipSize = 6
+    weapon.Primary.DefaultClip = 30
+    weapon.Primary.KickUp = 1
+    weapon.Primary.KickDown = 0.5
+    weapon.Primary.KickHorizontal = 0.5
+    weapon.Primary.Automatic = false
+    weapon.Primary.Ammo = "357"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 29
+    weapon.Primary.Spread = .02
+    weapon.Primary.IronAccuracy = .01
+end )

--- a/lua/cfc_entity_stubber/m9k/small_arms/m9k_deagle.lua
+++ b/lua/cfc_entity_stubber/m9k/small_arms/m9k_deagle.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_deagle" )
+    weapon.Primary.RPM = 600
+    weapon.Primary.ClipSize = 7
+    weapon.Primary.DefaultClip = 30
+    weapon.Primary.KickUp = 1
+    weapon.Primary.KickDown = 0.5
+    weapon.Primary.KickHorizontal = 0.5
+    weapon.Primary.Automatic = false
+    weapon.Primary.Ammo = "357"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 30
+    weapon.Primary.Spread = .025
+    weapon.Primary.IronAccuracy = .015
+end )

--- a/lua/cfc_entity_stubber/m9k/small_arms/m9k_glock.lua
+++ b/lua/cfc_entity_stubber/m9k/small_arms/m9k_glock.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_glock" )
+    weapon.Primary.RPM = 1200
+    weapon.Primary.ClipSize = 32
+    weapon.Primary.DefaultClip = 64
+    weapon.Primary.KickUp = 0.4
+    weapon.Primary.KickDown = 0.3
+    weapon.Primary.KickHorizontal = 0.3
+    weapon.Primary.Automatic = true
+    weapon.Primary.Ammo = "pistol"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 12
+    weapon.Primary.Spread = .03
+    weapon.Primary.IronAccuracy = .02
+end )

--- a/lua/cfc_entity_stubber/m9k/small_arms/m9k_hk45.lua
+++ b/lua/cfc_entity_stubber/m9k/small_arms/m9k_hk45.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_hk45" )
+    weapon.Primary.RPM = 750
+    weapon.Primary.ClipSize = 8
+    weapon.Primary.DefaultClip = 45
+    weapon.Primary.KickUp = 0.4
+    weapon.Primary.KickDown = 0.3
+    weapon.Primary.KickHorizontal = 0.3
+    weapon.Primary.Automatic = false
+    weapon.Primary.Ammo = "pistol"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 25
+    weapon.Primary.Spread = .025
+    weapon.Primary.IronAccuracy = .015
+end )

--- a/lua/cfc_entity_stubber/m9k/small_arms/m9k_honeybadger.lua
+++ b/lua/cfc_entity_stubber/m9k/small_arms/m9k_honeybadger.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_honeybadger" )
+    weapon.Primary.RPM = 791
+    weapon.Primary.ClipSize = 30
+    weapon.Primary.DefaultClip = 60
+    weapon.Primary.KickUp = .5
+    weapon.Primary.KickDown = .3
+    weapon.Primary.KickHorizontal = .5
+    weapon.Primary.Automatic = true
+    weapon.Primary.Ammo = "ar2"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 24
+    weapon.Primary.Spread = .023
+    weapon.Primary.IronAccuracy = .014
+end )

--- a/lua/cfc_entity_stubber/m9k/small_arms/m9k_kac_pdw.lua
+++ b/lua/cfc_entity_stubber/m9k/small_arms/m9k_kac_pdw.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_kac_pdw" )
+    weapon.Primary.RPM = 600
+    weapon.Primary.ClipSize = 30
+    weapon.Primary.DefaultClip = 60
+    weapon.Primary.KickUp = 0.1
+    weapon.Primary.KickDown = 0.1
+    weapon.Primary.KickHorizontal = 0.2
+    weapon.Primary.Automatic = true
+    weapon.Primary.Ammo = "smg1"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 15
+    weapon.Primary.Spread = .025
+    weapon.Primary.IronAccuracy = .015
+end )

--- a/lua/cfc_entity_stubber/m9k/small_arms/m9k_luger.lua
+++ b/lua/cfc_entity_stubber/m9k/small_arms/m9k_luger.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_luger" )
+    weapon.Primary.RPM = 825
+    weapon.Primary.ClipSize = 8
+    weapon.Primary.DefaultClip = 45
+    weapon.Primary.KickUp = 0.35
+    weapon.Primary.KickDown = 0.3
+    weapon.Primary.KickHorizontal = 0.2
+    weapon.Primary.Automatic = false
+    weapon.Primary.Ammo = "pistol"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 23
+    weapon.Primary.Spread = .021
+    weapon.Primary.IronAccuracy = .011
+end )

--- a/lua/cfc_entity_stubber/m9k/small_arms/m9k_m29satan.lua
+++ b/lua/cfc_entity_stubber/m9k/small_arms/m9k_m29satan.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_m29satan" )
+    weapon.Primary.RPM = 115
+    weapon.Primary.ClipSize = 6
+    weapon.Primary.DefaultClip = 30
+    weapon.Primary.KickUp = 1
+    weapon.Primary.KickDown = 0.5
+    weapon.Primary.KickHorizontal = 0.5
+    weapon.Primary.Automatic = false
+    weapon.Primary.Ammo = "357"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 32
+    weapon.Primary.Spread = .015
+    weapon.Primary.IronAccuracy = .01
+end )

--- a/lua/cfc_entity_stubber/m9k/small_arms/m9k_m92beretta.lua
+++ b/lua/cfc_entity_stubber/m9k/small_arms/m9k_m92beretta.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_m92beretta" )
+    weapon.Primary.RPM = 500
+    weapon.Primary.ClipSize = 15
+    weapon.Primary.DefaultClip = 45
+    weapon.Primary.KickUp = 1
+    weapon.Primary.KickDown = 0.5
+    weapon.Primary.KickHorizontal = 0.5
+    weapon.Primary.Automatic = false
+    weapon.Primary.Ammo = "pistol"
+    weapon.Primary.NumShots = 1//howmanybulletstoshoot,usewithshotguns
+    weapon.Primary.Damage = 14//basedamage,scaledbygame
+    weapon.Primary.Spread = .027//definefrom
+    weapon.Primary.IronAccuracy = .019//hastobethesameasprimary.spread
+end )

--- a/lua/cfc_entity_stubber/m9k/small_arms/m9k_magpulpdr.lua
+++ b/lua/cfc_entity_stubber/m9k/small_arms/m9k_magpulpdr.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_magpulpdr" )
+    weapon.Primary.RPM = 575
+    weapon.Primary.ClipSize = 30
+    weapon.Primary.DefaultClip = 60
+    weapon.Primary.KickUp = 0.3
+    weapon.Primary.KickDown = 0.3
+    weapon.Primary.KickHorizontal = 0.3
+    weapon.Primary.Automatic = true
+    weapon.Primary.Ammo = "smg1"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 30
+    weapon.Primary.Spread = .03
+    weapon.Primary.IronAccuracy = .02
+end )

--- a/lua/cfc_entity_stubber/m9k/small_arms/m9k_model3russian.lua
+++ b/lua/cfc_entity_stubber/m9k/small_arms/m9k_model3russian.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_model3russian" )
+    weapon.Primary.RPM = 115
+    weapon.Primary.ClipSize = 6
+    weapon.Primary.DefaultClip = 30
+    weapon.Primary.KickUp = 1
+    weapon.Primary.KickDown = 0.5
+    weapon.Primary.KickHorizontal = 0.5
+    weapon.Primary.Automatic = false
+    weapon.Primary.Ammo = "357"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 30
+    weapon.Primary.Spread = .02
+    weapon.Primary.IronAccuracy = .01
+end )

--- a/lua/cfc_entity_stubber/m9k/small_arms/m9k_model500.lua
+++ b/lua/cfc_entity_stubber/m9k/small_arms/m9k_model500.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_model500" )
+    weapon.Primary.RPM = 100
+    weapon.Primary.ClipSize = 5
+    weapon.Primary.DefaultClip = 30
+    weapon.Primary.KickUp = 1
+    weapon.Primary.KickDown = 0.3
+    weapon.Primary.KickHorizontal = 1
+    weapon.Primary.Automatic = false
+    weapon.Primary.Ammo = "357"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 40
+    weapon.Primary.Spread = .02
+    weapon.Primary.IronAccuracy = .015
+end )

--- a/lua/cfc_entity_stubber/m9k/small_arms/m9k_model627.lua
+++ b/lua/cfc_entity_stubber/m9k/small_arms/m9k_model627.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_model627" )
+    weapon.Primary.RPM = 120
+    weapon.Primary.ClipSize = 6
+    weapon.Primary.DefaultClip = 30
+    weapon.Primary.KickUp = 0.3
+    weapon.Primary.KickDown = 0.3
+    weapon.Primary.KickHorizontal = 0.3
+    weapon.Primary.Automatic = true
+    weapon.Primary.Ammo = "357"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 20
+    weapon.Primary.Spread = .01
+    weapon.Primary.IronAccuracy = .001
+end )

--- a/lua/cfc_entity_stubber/m9k/small_arms/m9k_mp40.lua
+++ b/lua/cfc_entity_stubber/m9k/small_arms/m9k_mp40.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_mp40" )
+    weapon.Primary.RPM = 500
+    weapon.Primary.ClipSize = 32
+    weapon.Primary.DefaultClip = 64
+    weapon.Primary.KickUp = 0.3
+    weapon.Primary.KickDown = 0.2
+    weapon.Primary.KickHorizontal = 0.4
+    weapon.Primary.Automatic = true
+    weapon.Primary.Ammo = "smg1"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 25
+    weapon.Primary.Spread = .022
+    weapon.Primary.IronAccuracy = .015
+end )

--- a/lua/cfc_entity_stubber/m9k/small_arms/m9k_mp5.lua
+++ b/lua/cfc_entity_stubber/m9k/small_arms/m9k_mp5.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_mp5" )
+    weapon.Primary.RPM = 800
+    weapon.Primary.ClipSize = 30
+    weapon.Primary.DefaultClip = 60
+    weapon.Primary.KickUp = 0.1
+    weapon.Primary.KickDown = 0.1
+    weapon.Primary.KickHorizontal = 0.2
+    weapon.Primary.Automatic = true
+    weapon.Primary.Ammo = "smg1"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 22
+    weapon.Primary.Spread = .023
+    weapon.Primary.IronAccuracy = .013
+end )

--- a/lua/cfc_entity_stubber/m9k/small_arms/m9k_mp5sd.lua
+++ b/lua/cfc_entity_stubber/m9k/small_arms/m9k_mp5sd.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_mp5sd" )
+    weapon.Primary.RPM = 700
+    weapon.Primary.ClipSize = 30
+    weapon.Primary.DefaultClip = 60
+    weapon.Primary.KickUp = 0.2
+    weapon.Primary.KickDown = 0.3
+    weapon.Primary.KickHorizontal = 0.2
+    weapon.Primary.Automatic = true
+    weapon.Primary.Ammo = "smg1"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 30
+    weapon.Primary.Spread = .025
+    weapon.Primary.IronAccuracy = .015
+end )

--- a/lua/cfc_entity_stubber/m9k/small_arms/m9k_mp7.lua
+++ b/lua/cfc_entity_stubber/m9k/small_arms/m9k_mp7.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_mp7" )
+    weapon.Primary.RPM = 950
+    weapon.Primary.ClipSize = 30
+    weapon.Primary.DefaultClip = 60
+    weapon.Primary.KickUp = .5
+    weapon.Primary.KickDown = .4
+    weapon.Primary.KickHorizontal = .4
+    weapon.Primary.Automatic = true
+    weapon.Primary.Ammo = "smg1"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 24
+    weapon.Primary.Spread = .023
+    weapon.Primary.IronAccuracy = .014
+end )

--- a/lua/cfc_entity_stubber/m9k/small_arms/m9k_mp9.lua
+++ b/lua/cfc_entity_stubber/m9k/small_arms/m9k_mp9.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_mp9" )
+    weapon.Primary.RPM = 900
+    weapon.Primary.ClipSize = 30
+    weapon.Primary.DefaultClip = 60
+    weapon.Primary.KickUp = 0.2
+    weapon.Primary.KickDown = 0.1
+    weapon.Primary.KickHorizontal = 0.2
+    weapon.Primary.Automatic = true
+    weapon.Primary.Ammo = "ar2"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 20
+    weapon.Primary.Spread = .023
+    weapon.Primary.IronAccuracy = .014
+end )

--- a/lua/cfc_entity_stubber/m9k/small_arms/m9k_ragingbull.lua
+++ b/lua/cfc_entity_stubber/m9k/small_arms/m9k_ragingbull.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_ragingbull" )
+    weapon.Primary.RPM = 115
+    weapon.Primary.ClipSize = 6
+    weapon.Primary.DefaultClip = 30
+    weapon.Primary.KickUp = 1
+    weapon.Primary.KickDown = 0.5
+    weapon.Primary.KickHorizontal = 0.5
+    weapon.Primary.Automatic = false
+    weapon.Primary.Ammo = "357"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 31
+    weapon.Primary.Spread = .02
+    weapon.Primary.IronAccuracy = .001
+end )

--- a/lua/cfc_entity_stubber/m9k/small_arms/m9k_remington1858.lua
+++ b/lua/cfc_entity_stubber/m9k/small_arms/m9k_remington1858.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_remington1858" )
+    weapon.Primary.RPM = 150
+    weapon.Primary.ClipSize = 6
+    weapon.Primary.DefaultClip = 30
+    weapon.Primary.KickUp = 0.9
+    weapon.Primary.KickDown = 0.5
+    weapon.Primary.KickHorizontal = 0.4
+    weapon.Primary.Automatic = false
+    weapon.Primary.Ammo = "357"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 34
+    weapon.Primary.Spread = .025
+    weapon.Primary.IronAccuracy = .012
+end )

--- a/lua/cfc_entity_stubber/m9k/small_arms/m9k_scoped_taurus.lua
+++ b/lua/cfc_entity_stubber/m9k/small_arms/m9k_scoped_taurus.lua
@@ -1,0 +1,16 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_scoped_taurus" )
+    weapon.Primary.RPM = 115
+    weapon.Primary.ClipSize = 6
+    weapon.Primary.DefaultClip = 30
+    weapon.Primary.KickUp = 10
+    weapon.Primary.KickDown = .5
+    weapon.Primary.KickHorizontal = 1
+    weapon.Primary.Automatic = false
+    weapon.Primary.Ammo = "357"
+    weapon.Primary.Damage = 31
+    weapon.Primary.Spread = .02
+    weapon.Primary.IronAccuracy = .0001
+end )

--- a/lua/cfc_entity_stubber/m9k/small_arms/m9k_sig_p229r.lua
+++ b/lua/cfc_entity_stubber/m9k/small_arms/m9k_sig_p229r.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_sig_p229r" )
+    weapon.Primary.RPM = 500
+    weapon.Primary.ClipSize = 12
+    weapon.Primary.DefaultClip = 45
+    weapon.Primary.KickUp = 0.4
+    weapon.Primary.KickDown = 0.3
+    weapon.Primary.KickHorizontal = 0.3
+    weapon.Primary.Automatic = false
+    weapon.Primary.Ammo = "pistol"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 17
+    weapon.Primary.Spread = .025
+    weapon.Primary.IronAccuracy = .015
+end )

--- a/lua/cfc_entity_stubber/m9k/small_arms/m9k_smgp90.lua
+++ b/lua/cfc_entity_stubber/m9k/small_arms/m9k_smgp90.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_smgp90" )
+    weapon.Primary.RPM = 900
+    weapon.Primary.ClipSize = 50
+    weapon.Primary.DefaultClip = 100
+    weapon.Primary.KickUp = 0.6
+    weapon.Primary.KickDown = 0.4
+    weapon.Primary.KickHorizontal = 0.5
+    weapon.Primary.Automatic = true
+    weapon.Primary.Ammo = "smg1"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 18
+    weapon.Primary.Spread = .032
+    weapon.Primary.IronAccuracy = .02
+end )

--- a/lua/cfc_entity_stubber/m9k/small_arms/m9k_sten.lua
+++ b/lua/cfc_entity_stubber/m9k/small_arms/m9k_sten.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_sten" )
+    weapon.Primary.RPM = 500
+    weapon.Primary.ClipSize = 32
+    weapon.Primary.DefaultClip = 60
+    weapon.Primary.KickUp = 0.6
+    weapon.Primary.KickDown = 0.4
+    weapon.Primary.KickHorizontal = 0.5
+    weapon.Primary.Automatic = true
+    weapon.Primary.Ammo = "smg1"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 20
+    weapon.Primary.Spread = .03
+    weapon.Primary.IronAccuracy = .016
+end )

--- a/lua/cfc_entity_stubber/m9k/small_arms/m9k_tec9.lua
+++ b/lua/cfc_entity_stubber/m9k/small_arms/m9k_tec9.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_tec9" )
+    weapon.Primary.RPM = 825
+    weapon.Primary.ClipSize = 32
+    weapon.Primary.DefaultClip = 60
+    weapon.Primary.KickUp = 0.2
+    weapon.Primary.KickDown = 0.3
+    weapon.Primary.KickHorizontal = 0.1
+    weapon.Primary.Automatic = true
+    weapon.Primary.Ammo = "smg1"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 17
+    weapon.Primary.Spread = .029
+    weapon.Primary.IronAccuracy = .019
+end )

--- a/lua/cfc_entity_stubber/m9k/small_arms/m9k_thompson.lua
+++ b/lua/cfc_entity_stubber/m9k/small_arms/m9k_thompson.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_thompson" )
+    weapon.Primary.RPM = 575
+    weapon.Primary.ClipSize = 75
+    weapon.Primary.DefaultClip = 150
+    weapon.Primary.KickUp = 0.7
+    weapon.Primary.KickDown = 0.6
+    weapon.Primary.KickHorizontal = 0.65
+    weapon.Primary.Automatic = true
+    weapon.Primary.Ammo = "smg1"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 22
+    weapon.Primary.Spread = .03
+    weapon.Primary.IronAccuracy = .019
+end )

--- a/lua/cfc_entity_stubber/m9k/small_arms/m9k_ump45.lua
+++ b/lua/cfc_entity_stubber/m9k/small_arms/m9k_ump45.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_ump45" )
+    weapon.Primary.RPM = 600
+    weapon.Primary.ClipSize = 25
+    weapon.Primary.DefaultClip = 60
+    weapon.Primary.KickUp = 0.2
+    weapon.Primary.KickDown = 0.4
+    weapon.Primary.KickHorizontal = 0.45
+    weapon.Primary.Automatic = true
+    weapon.Primary.Ammo = "smg1"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 20
+    weapon.Primary.Spread = .028
+    weapon.Primary.IronAccuracy = .018
+end )

--- a/lua/cfc_entity_stubber/m9k/small_arms/m9k_usc.lua
+++ b/lua/cfc_entity_stubber/m9k/small_arms/m9k_usc.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_usc" )
+    weapon.Primary.RPM = 600
+    weapon.Primary.ClipSize = 25
+    weapon.Primary.DefaultClip = 60
+    weapon.Primary.KickUp = 0.2
+    weapon.Primary.KickDown = 0.4
+    weapon.Primary.KickHorizontal = 0.45
+    weapon.Primary.Automatic = false
+    weapon.Primary.Ammo = "smg1"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 23
+    weapon.Primary.Spread = .02
+    weapon.Primary.IronAccuracy = .01
+end )

--- a/lua/cfc_entity_stubber/m9k/small_arms/m9k_usp.lua
+++ b/lua/cfc_entity_stubber/m9k/small_arms/m9k_usp.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_usp" )
+    weapon.Primary.RPM = 750
+    weapon.Primary.ClipSize = 15
+    weapon.Primary.DefaultClip = 45
+    weapon.Primary.KickUp = 0.3
+    weapon.Primary.KickDown = 0.3
+    weapon.Primary.KickHorizontal = 0.3
+    weapon.Primary.Automatic = false
+    weapon.Primary.Ammo = "pistol"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 16
+    weapon.Primary.Spread = .02
+    weapon.Primary.IronAccuracy = .01
+end )

--- a/lua/cfc_entity_stubber/m9k/small_arms/m9k_uzi.lua
+++ b/lua/cfc_entity_stubber/m9k/small_arms/m9k_uzi.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_uzi" )
+    weapon.Primary.RPM = 600
+    weapon.Primary.ClipSize = 32
+    weapon.Primary.DefaultClip = 64
+    weapon.Primary.KickUp = 0.3
+    weapon.Primary.KickDown = 0.3
+    weapon.Primary.KickHorizontal = 0.3
+    weapon.Primary.Automatic = true
+    weapon.Primary.Ammo = "smg1"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 20
+    weapon.Primary.Spread = .028
+    weapon.Primary.IronAccuracy = .018
+end )

--- a/lua/cfc_entity_stubber/m9k/small_arms/m9k_vector.lua
+++ b/lua/cfc_entity_stubber/m9k/small_arms/m9k_vector.lua
@@ -1,0 +1,17 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "m9k_vector" )
+    weapon.Primary.RPM = 1000
+    weapon.Primary.ClipSize = 30
+    weapon.Primary.DefaultClip = 60
+    weapon.Primary.KickUp = 0.2
+    weapon.Primary.KickDown = 0.1
+    weapon.Primary.KickHorizontal = 0.3
+    weapon.Primary.Automatic = true
+    weapon.Primary.Ammo = "smg1"
+    weapon.Primary.NumShots = 1
+    weapon.Primary.Damage = 18
+    weapon.Primary.Spread = .026
+    weapon.Primary.IronAccuracy = .014
+end )


### PR DESCRIPTION
This PR aims adds all default m9k addon weapon values (not cfc's m9k values). These weapons are nowhere near balanced in the current cfc environment BUT will allow for a better base to work from than the M9kR weapon values.