### PR TITLE
Use xpcall instead of protected call

### DIFF
--- a/lua/cfc_entity_stubber/main_loader.lua
+++ b/lua/cfc_entity_stubber/main_loader.lua
@@ -51,11 +51,17 @@ end
 
 function cfcEntityStubber.runStubs( stubQueue )
     for _, stub in pairs( stubQueue ) do
-        local function catch( err )
-            cfcEntityStubber.printMessage( "ERROR: " .. err, Color( 255, 125, 0 ) )
+        if SERVER then
+            ProtectedCall( stub )
         end
 
-        xpcall( stub, catch )
+        if CLIENT then
+            local function catch( err )
+                cfcEntityStubber.printMessage( "ERROR: " .. err, Color( 255, 125, 0 ) )
+            end
+
+            xpcall( stub, catch )
+        end
     end
 end
 

--- a/lua/cfc_entity_stubber/main_loader.lua
+++ b/lua/cfc_entity_stubber/main_loader.lua
@@ -51,7 +51,11 @@ end
 
 function cfcEntityStubber.runStubs( stubQueue )
     for _, stub in pairs( stubQueue ) do
-        ProtectedCall( stub )
+        local function catch( err )
+            cfcEntityStubber.printMessage( "ERROR: " .. err, Color( 255, 125, 0 ) )
+        end
+
+        xpcall( stub, catch )
     end
 end
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/69946827/126532374-f0aa213e-3eba-4a61-90af-cd5e15bb3315.png)
this prevent people from getting errors in their error log or popups on the top of their screen while still displaying errors